### PR TITLE
Add option to hide background colors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,4 +8,5 @@ export type Config = Theme & {
     WRAP_LINES: boolean;
     HIGHLIGHT_LINE_CHANGES: boolean;
     SYNTAX_HIGHLIGHTING_THEME?: string;
+    HIDE_BACKGROUND: boolean;
 };

--- a/src/getGitConfig.ts
+++ b/src/getGitConfig.ts
@@ -34,7 +34,8 @@ export async function getGitConfig(
 
     // Defaults to "dark"
     const themeName = rawConfig['theme-name'] ?? 'dark';
-    const theme = loadTheme(themeName);
+    const hideBackground = rawConfig['hide-background'] === 'true';
+    const theme = loadTheme(themeName, hideBackground);
 
     // Defaults to the theme's setting
     const syntaxHighlightingTheme =
@@ -65,5 +66,6 @@ export async function getGitConfig(
         WRAP_LINES: wrapLines,
         HIGHLIGHT_LINE_CHANGES: highlightLineChanges,
         SYNTAX_HIGHLIGHTING_THEME: syntaxHighlightingTheme,
+        HIDE_BACKGROUND: hideBackground,
     };
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -48,6 +48,15 @@ export enum ThemeColorName {
     MISSING_LINE_COLOR = 'MISSING_LINE_COLOR',
 }
 
+export const NO_BACKGROUND_THEME_COLORS: ThemeColorName[] = [
+    ThemeColorName.COMMIT_HEADER_COLOR,
+    ThemeColorName.COMMIT_MESSAGE_COLOR,
+    ThemeColorName.BORDER_COLOR,
+    ThemeColorName.FILE_NAME_COLOR,
+    ThemeColorName.UNMODIFIED_LINE_NO_COLOR,
+    ThemeColorName.UNMODIFIED_LINE_COLOR,
+];
+
 export type ThemeDefinition = {
     SYNTAX_HIGHLIGHTING_THEME?: string;
 } & {
@@ -162,7 +171,10 @@ function loadThemeDefinition(themeName: string): ThemeDefinition {
     ) as ThemeDefinition;
 }
 
-export function loadTheme(themeName: string): Theme {
+export function loadTheme(
+    themeName: string,
+    hideBackground: boolean = false
+): Theme {
     const themeDefinition = loadThemeDefinition(themeName);
 
     const theme: Partial<Theme> = {
@@ -176,6 +188,13 @@ export function loadTheme(themeName: string): Theme {
             assert.fail(`${variableName} is missing in theme`);
         }
         theme[variableName] = parseColorDefinition(value);
+
+        if (
+            hideBackground &&
+            NO_BACKGROUND_THEME_COLORS.includes(variableName)
+        ) {
+            (theme[variableName] as ThemeColor).backgroundColor = undefined;
+        }
     }
 
     return theme as Theme;

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -55,6 +55,7 @@ export const NO_BACKGROUND_THEME_COLORS: ThemeColorName[] = [
     ThemeColorName.FILE_NAME_COLOR,
     ThemeColorName.UNMODIFIED_LINE_NO_COLOR,
     ThemeColorName.UNMODIFIED_LINE_COLOR,
+    ThemeColorName.MISSING_LINE_COLOR,
 ];
 
 export type ThemeDefinition = {


### PR DESCRIPTION
Added a config option called hide-background which, when enabled, will render the following colors with transparent backgrounds:
- COMMIT_HEADER_COLOR
- COMMIT_MESSAGE_COLOR
- BORDER_COLOR
- FILE_NAME_COLOR
- UNMODIFIED_LINE_NO_COLOR
- UNMODIFIED_LINE_COLOR
- MISSING_LINE_COLOR

The result (using `github-dark-dim`):

<img width="1578" alt="Screen Shot 2021-05-01 at 9 22 06 PM" src="https://user-images.githubusercontent.com/10377391/116799018-5537d880-aac3-11eb-845e-609409366e6c.png">

It's somewhat debatable whether HUNK_HEADER_COLOR should be included as well

Closes #7