### PR TITLE
Add a note about the --color flag to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ GitHub style split diffs with syntax highlighting in your terminal.
 
 ## Usage
 
-This currently requires `node` version 12 or newer to run.
+This currently requires `node` version 12 or newer to run. 
+
+Text coloring is implemented using Chalk which supports [various levels of color](https://github.com/chalk/chalk#supportscolor).
+If Chalk is producing fewer colors than your terminal supports, try overriding Chalk's detection using a 
+variation of the `--color` flag, e.g. `--color=16m` for true color. 
+See Chalk's documentation or [this useful gist on terminal support](https://gist.github.com/XVilka/8346728) if issues persist.
 
 ### Install globally
 


### PR DESCRIPTION
I learned more than I wanted to about color handling getting my layers of ssh and shells to show 24-bit color. 
Now I too see diffs as the screen captures show with those gorgeous light-green and red background shades! 
This little note will hopefully help the next soul to find their way to information about Chalk and colors in terminals.
At least on my machine (ubuntu), `--color` by itself produced a 256 color palette.